### PR TITLE
Feature: Add Via-Cep API Wrapper - Fixed #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 coverage/
 dist/
 lib/
+tsconfig.tsbuildinfo

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm commitlint --edit "$1"
+yarn commitlint --edit "$1"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm run test
+yarn run test

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,7 @@
     "clean": "rimraf dist",
     "build": "yarn run clean && tsc && tsc-alias",
     "test": "jest --coverage --no-cache --passWithNoTests",
-    "dev": "ts-node --esm -r tsconfig-paths/register src/index.ts"
+    "dev": "ts-node -r tsconfig-paths/register src/index.ts"
   },
   "devDependencies": {
     "@types/jest": "^29.5.4",

--- a/packages/cli/src/core/sdks/cep-aberto.ts
+++ b/packages/cli/src/core/sdks/cep-aberto.ts
@@ -164,5 +164,3 @@ cepAberto
 			copyToClipboard: copy,
 		});
 	});
-
-program.parse(process.argv);

--- a/packages/cli/src/core/sdks/index.ts
+++ b/packages/cli/src/core/sdks/index.ts
@@ -1,1 +1,2 @@
 export * from "./cep-aberto";
+export * from "./via-cep";

--- a/packages/cli/src/core/sdks/via-cep.ts
+++ b/packages/cli/src/core/sdks/via-cep.ts
@@ -3,7 +3,7 @@ import { ViaCepAPI } from "@brasil-interface/sdks";
 import { program } from "commander";
 
 const viaCep = program
-	.command("viacep")
+	.command("via-cep")
 	.description("ViaCepAPI utilities.");
 
 viaCep

--- a/packages/cli/src/core/sdks/via-cep.ts
+++ b/packages/cli/src/core/sdks/via-cep.ts
@@ -1,0 +1,32 @@
+import { OutputHelper } from "@/helpers/output-helper";
+import { ViaCepAPI } from "@brasil-interface/sdks";
+import { program } from "commander";
+
+const viaCep = program
+	.command("viacep")
+	.description("ViaCepAPI utilities.");
+
+viaCep
+	.command("get-by-number <cep>")
+	.description(
+		"PT-BR: Obtém informações de endereço pelo número do CEP. EN-US: Get address information by CEP number."
+	)
+	.option(
+		"-o, --output <filepath>",
+		"PT-BR: Caminho do arquivo de output. EN-US: Output file path"
+	)
+	.option(
+		"-c, --copy",
+		"PT-BR: Copia o resultado para a área de transferência. EN-US: Copy the result to the clipboard."
+	)
+	.action(async (cep, options) => {
+		const { output, copy } = options;
+		const viaCepAPI = new ViaCepAPI();
+
+		const result = await viaCepAPI.getCepByNumber(cep);
+
+		OutputHelper.handleResultOutputBasedOnOptions(result, {
+			output,
+			copyToClipboard: copy,
+		});
+	});

--- a/packages/sdks/src/core/via-cep/via-cep.spec.ts
+++ b/packages/sdks/src/core/via-cep/via-cep.spec.ts
@@ -1,0 +1,55 @@
+import { ViaCepAPI } from "./via-cep";
+
+describe("ViaCepAPI", () => {
+	let viaCepAPI: ViaCepAPI;
+
+	beforeEach(() => {
+		viaCepAPI = new ViaCepAPI();
+	});
+
+	describe("fetch response", () => {
+		const mockFetch = (response: any, status = 200) => {
+			return jest.fn().mockImplementation(() =>
+				Promise.resolve({
+					ok: true,
+					status,
+					json: () => Promise.resolve(response),
+				})
+			);
+		};
+
+		beforeEach(() => {
+			global.fetch = mockFetch({});
+		});
+
+		afterEach(() => {
+			jest.restoreAllMocks();
+		});
+
+		describe("getCepByNumber", () => {
+			it("should return address information for a given CEP number", async () => {
+				const cep = "01001000";
+				const expectedResponse = {
+					cep: "01001-000",
+					logradouro: "Praça da Sé",
+					complemento: "lado ímpar",
+					bairro: "Sé",
+					localidade: "São Paulo",
+					uf: "SP",
+					ibge: "3550308",
+					gia: "1004",
+					ddd: "11",
+					siafi: "7107"
+				};
+				global.fetch = mockFetch(expectedResponse);
+
+				const response = await viaCepAPI.getCepByNumber(cep);
+
+				expect(response).toEqual(expectedResponse);
+				expect(fetch).toHaveBeenCalledWith(
+					`https://viacep.com.br/ws/${cep}/json/`
+				);
+			});
+		});
+	});
+});

--- a/packages/sdks/src/core/via-cep/via-cep.ts
+++ b/packages/sdks/src/core/via-cep/via-cep.ts
@@ -1,0 +1,33 @@
+import {
+	ViaCepAddress
+} from "./via-cep.types";
+
+export class ViaCepAPI {
+	private baseUrl = "https://viacep.com.br";
+
+	constructor() {}
+
+	private async fetchJson<T>(url: string): Promise<T> {
+		const response = await fetch(url);
+
+		if (!response.ok) {
+			throw new Error(
+				`Failed to fetch ${url}: ${response.status} ${response.statusText}`
+			);
+		}
+
+		return response.json();
+	}
+
+	/**
+	 * PT-BR: Obtém informações de endereço pelo número do CEP.
+	 * EN-US: Get address information by CEP number.
+	 *
+	 * @param cep PT-BR: O número do CEP. EN-US: The CEP number.
+	 * @returns PT-BR: As informações de endereço para o CEP fornecido. EN-US: The address information for the provided CEP.
+	 */
+	public async getCepByNumber(cep: string): Promise<ViaCepAddress> {
+		const url = `${this.baseUrl}/ws/${cep}/json/`;
+		return this.fetchJson<ViaCepAddress>(url);
+	}
+}

--- a/packages/sdks/src/core/via-cep/via-cep.types.ts
+++ b/packages/sdks/src/core/via-cep/via-cep.types.ts
@@ -1,0 +1,14 @@
+import { EstadoSigla } from "@brasil-interface/utils";
+
+export type ViaCepAddress = {
+    cep: string;
+    logradouro: string;
+    complemento?: string;
+    bairro: string;
+    localidade: string;
+    uf: EstadoSigla;
+    ibge: string;
+    gia: string;
+    ddd: string;
+    siafi: string;
+}

--- a/packages/sdks/src/index.ts
+++ b/packages/sdks/src/index.ts
@@ -1,1 +1,2 @@
 export { CepAbertoAPI } from "./core/cep-aberto/cep-aberto";
+export { ViaCepAPI } from "./core/via-cep/via-cep";


### PR DESCRIPTION
### Template de Pull Request

---

**Resumo**
Foi adicionado o novo comando "via-cep" no projeto "CLI" para busca de CEP, baseado na Issue #2 

Exemplo da solicitação:
`via-cep get-by-number 01001000`

Exemplo do resultado:
`{
  cep: '01001-000',
  logradouro: 'Praça da Sé',
  complemento: 'lado ímpar',
  bairro: 'Sé',
  localidade: 'São Paulo',
  uf: 'SP',
  ibge: '3550308',
  gia: '1004',
  ddd: '11',
  siafi: '7107'
}`

Além de correção para não sobrescrever os comandos para o "cli".

**Descrição**
Modificações baseadas na Issue #2
- Feature: Adicionar via-cep API Wrapper
- Tests: Teste unitário da feature acima

Ajustes necessários
- Mudar o comando "pnpm" para "yarn" nos arquivos do Husky
- Remover a flag "--esm" do arquivo packages/cli/package.json
- Remover código de "program.parse" que sobrescrevia os comandos do projeto CLI
- Adicionar o arquivo auto-gerado "tsconfig.tsbuildinfo" ao gitignore

**Tipo de mudança**
- [X] Bug fix (alteração que corrige uma falha e não interfere em recursos já existentes)
- [X] Nova feature (alteração que adiciona uma funcionalidade)
- [ ] Alteração de feature existente (fix ou feature que já existe)
- [ ] Documentação

**Checklist**
- [X] Meu código segue os padrões do projeto.
- [X] Eu revisei meu próprio código.
- [X] Eu comentei meu código em áreas difíceis de entender.
- [X] Eu atualizei a documentação de acordo com minhas mudanças.
- [X] Eu adicionei testes que provam que minha correção é eficaz ou que minha feature funciona.
- [X] Testes novos e existentes passam localmente com minhas mudanças.
- [X] Eu adicionei informações necessárias ao log de mudanças.

**Passos adicionais**
- [X] Nenhuma dependência de outros PR's.

**Referências**
- Site do Via-Cep: https://viacep.com.br/
